### PR TITLE
ci: add build number counting to android

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -42,6 +42,9 @@ jobs:
         run: |
           echo "PACKAGE_NUMBER=$(jq -r '.version' package.json)" >> "$GITHUB_ENV"
           echo "BUILD_NUMBER=$((${{ vars.ANDROID_BUILD_NUMBER }} + 1))" >> "$GITHUB_ENV"
+
+      - name: Update build number
+        run: |
           curl -L -X PATCH -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.API_TOKEN }}" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/orgs/acc-hymns/actions/variables/ANDROID_BUILD_NUMBER -d '{"value":"${{ env.BUILD_NUMBER }}"}'
 
       - name: Build app bundle

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -7,8 +7,19 @@ on:
       - ".github/.workflows/**"
 
 jobs:
+  wait:
+    name: Wait for Previous IOS Builds to finish
+    runs-on: ubuntu-latest
+    steps:
+      # We do this so we don't ever have conflicting build numbers
+      - uses: ahmadnassri/action-workflow-queue@v1
+        with:
+          timeout: 3600000
+          delay: 1000
+
   build:
     name: Build Android
+    needs: wait
     runs-on: ubuntu-latest
 
     steps:
@@ -31,12 +42,6 @@ jobs:
           npm install
           npm run deploy-check
           npm run build
-
-      # We do this so we don't ever have conflicting build numbers
-      - name: Wait for other build-android to conclude
-        uses: ahmadnassri/action-workflow-queue@v1
-        with:
-          timeout: 3600000
       
       - name: Get & update build number
         run: |
@@ -57,7 +62,15 @@ jobs:
           chmod +x ./android/gradlew
           npx cap build android --keystorepath release.jks --keystorepass ${{ secrets.KEYSTORE_PASSWORD }} --keystorealias upload-keystore --keystorealiaspass ${{ secrets.KEYSTORE_PASSWORD }} --androidreleasetype APK
           npx cap build android --keystorepath release.jks --keystorepass ${{ secrets.KEYSTORE_PASSWORD }} --keystorealias upload-keystore --keystorealiaspass ${{ secrets.KEYSTORE_PASSWORD }} --androidreleasetype AAB
-
+ 
+      - name: Publish AAB
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.ANDROID_SERVICE_ACCOUNT_JSON }}
+          releaseFiles: ./android/app/build/outputs/bundle/release/app-release-signed.aab
+          packageName: com.ChristopherW.acchmns
+          track: internal
+          
       - name: Upload release AAB
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -10,6 +10,7 @@ jobs:
   build:
     name: Build Android
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout source
         uses: actions/checkout@v3
@@ -31,15 +32,17 @@ jobs:
           npm run deploy-check
           npm run build
 
+      # We do this so we don't ever have conflicting build numbers
       - name: Wait for other build-android to conclude
         uses: ahmadnassri/action-workflow-queue@v1
         with:
           timeout: 3600000
       
-      - name: Get build number
+      - name: Get & update build number
         run: |
           echo "PACKAGE_NUMBER=$(jq -r '.version' package.json)" >> "$GITHUB_ENV"
-          echo "BUILD_NUMBER=$(${{ vars.ANDROID_BUILD_NUMBER }} + 1)" >> "$GITHUB_ENV"
+          echo "BUILD_NUMBER=$((${{ vars.ANDROID_BUILD_NUMBER }} + 1))" >> "$GITHUB_ENV"
+          curl -L -X PATCH -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.API_TOKEN }}" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/orgs/acc-hymns/actions/variables/ANDROID_BUILD_NUMBER -d '{"value":"${{ env.BUILD_NUMBER }}"}'
 
       - name: Build app bundle
         run: |
@@ -65,8 +68,3 @@ jobs:
           name: app-release-apk
           path: android/app/build/outputs/apk/release/app-release-signed.apk
           retention-days: 7
-
-      - name: Update Build Number
-        if: always()
-        run: |
-          curl -L -X PATCH -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.API_TOKEN }}" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/orgs/acc-hymns/actions/variables/ANDROID_BUILD_NUMBER -d '{"value":"${{ env.BUILD_NUMBER }}"}'

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -19,21 +19,35 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '17'
+          
+      - name: Extract Android signing key from env
+        run: |
+          echo "${{ secrets.KEYSTORE_BASE64 }}" > android/release.jks.base64
+          base64 -d android/release.jks.base64 > android/release.jks
 
       - name: Build web app
         run: |
           npm install
           npm run deploy-check
           npm run build
-          npx cap sync
 
-      - name: Extract Android signing key from env
+      - name: Wait for other build-android to conclude
+        uses: ahmadnassri/action-workflow-queue@v1
+        with:
+          timeout: 3600000
+      
+      - name: Get build number
         run: |
-          echo "${{ secrets.KEYSTORE_BASE64 }}" > android/release.jks.base64
-          base64 -d android/release.jks.base64 > android/release.jks
+          echo "PACKAGE_NUMBER=$(jq -r '.version' package.json)" >> "$GITHUB_ENV"
+          echo "BUILD_NUMBER=$(${{ vars.ANDROID_BUILD_NUMBER }} + 1)" >> "$GITHUB_ENV"
 
       - name: Build app bundle
         run: |
+          npx cap sync
+          # Replace version codes
+          sed -i -E "s/versionCode ([0-9]+?)/versionCode ${{ env.BUILD_NUMBER}}/g" android/app/build.gradle
+          sed -i -E "s/versionName \"(.+?)\"/versionName \"${{ env.PACKAGE_NUMBER}}\"/g" android/app/build.gradle
+
           chmod +x ./android/gradlew
           npx cap build android --keystorepath release.jks --keystorepass ${{ secrets.KEYSTORE_PASSWORD }} --keystorealias upload-keystore --keystorealiaspass ${{ secrets.KEYSTORE_PASSWORD }} --androidreleasetype APK
           npx cap build android --keystorepath release.jks --keystorepass ${{ secrets.KEYSTORE_PASSWORD }} --keystorealias upload-keystore --keystorealiaspass ${{ secrets.KEYSTORE_PASSWORD }} --androidreleasetype AAB
@@ -51,3 +65,8 @@ jobs:
           name: app-release-apk
           path: android/app/build/outputs/apk/release/app-release-signed.apk
           retention-days: 7
+
+      - name: Update Build Number
+        if: always()
+        run: |
+          curl -L -X PATCH -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.API_TOKEN }}" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/orgs/acc-hymns/actions/variables/ANDROID_BUILD_NUMBER -d '{"value":"${{ env.BUILD_NUMBER }}"}'

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -15,7 +15,6 @@ jobs:
       - uses: ahmadnassri/action-workflow-queue@v1
         with:
           timeout: 3600000
-          delay: 1000
 
   build:
     name: Build Android
@@ -54,7 +53,7 @@ jobs:
 
       - name: Build app bundle
         run: |
-          npx cap sync
+          npx cap sync android
           # Replace version codes
           sed -i -E "s/versionCode ([0-9]+?)/versionCode ${{ env.BUILD_NUMBER}}/g" android/app/build.gradle
           sed -i -E "s/versionName \"(.+?)\"/versionName \"${{ env.PACKAGE_NUMBER}}\"/g" android/app/build.gradle

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -52,15 +52,17 @@ jobs:
           npm run deploy-check
           npm run build
 
+      # We do this so we don't ever have conflicting build numbers
       - name: Wait for other build-ios to conclude
         uses: ahmadnassri/action-workflow-queue@v1
         with:
           timeout: 3600000
       
-      - name: Get build number
+      - name: Get & update build number
         run: |
           echo "PACKAGE_NUMBER=$(jq -r '.version' package.json)" >> "$GITHUB_ENV"
-          echo "BUILD_NUMBER=$(${{ vars.IOS_BUILD_NUMBER }} + 1)" >> "$GITHUB_ENV"
+          echo "BUILD_NUMBER=$((${{ vars.IOS_BUILD_NUMBER }} + 1))" >> "$GITHUB_ENV"
+          curl -L -X PATCH -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.API_TOKEN }}" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/orgs/acc-hymns/actions/variables/IOS_BUILD_NUMBER -d '{"value":"${{ env.BUILD_NUMBER }}"}'
 
       - name: Build app bundle
         run: |
@@ -115,8 +117,3 @@ jobs:
           name: app-release-ipa
           path: ios/App/output/*.ipa
           retention-days: 7
-
-      - name: Update Build Number
-        if: always()
-        run: |
-          curl -L -X PATCH -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.API_TOKEN }}" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/orgs/acc-hymns/actions/variables/IOS_BUILD_NUMBER -d '{"value":"${{ env.BUILD_NUMBER }}"}'

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Build IOS
     runs-on: macos-latest
-    environment: development
+
     steps:
       - name: Checkout source
         uses: actions/checkout@v3
@@ -19,8 +19,6 @@ jobs:
       # https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development#add-a-step-to-your-workflow
       - name: Install the Apple certificate and provisioning profile
         run: |
-          echo "build_number=$((${{ vars.IOS_BUILD_NUMBER }}+1))" >> "$GITHUB_ENV"
-
           # create variables
           CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
           PP_PATH=$RUNNER_TEMP/build_pp.mobileprovision
@@ -50,17 +48,25 @@ jobs:
 
       - name: Build web app
         run: |
-          pwd
-          echo "$(pwd)"
           npm install
           npm run deploy-check
           npm run build
-        
+
+      - name: Wait for other build-ios to conclude
+        uses: ahmadnassri/action-workflow-queue@v1
+        with:
+          timeout: 3600000
+      
+      - name: Get build number
+        run: |
+          echo "PACKAGE_NUMBER=$(jq -r '.version' package.json)" >> "$GITHUB_ENV"
+          echo "BUILD_NUMBER=$(${{ vars.IOS_BUILD_NUMBER }} + 1)" >> "$GITHUB_ENV"
+
       - name: Build app bundle
         run: |
           npx cap sync
           cd ios/App
-          xcrun agvtool new-version -all ${{ env.build_number }}
+          xcrun agvtool new-version -all "${{ env.BUILD_NUMBER }}" new-marketing-version "${{ env.PACKAGE_NUMBER }}"
           echo "MARKET_VERSION=$(xcodebuild -showBuildSettings | grep MARKETING_VERSION | tr -d 'MARKETING_VERSION = ')" >> "$GITHUB_ENV"
           xcodebuild clean archive -workspace App.xcworkspace -scheme "ACC Hymns" -destination generic/platform=iOS -archivePath App.xcarchive -allowProvisioningUpdates
           
@@ -111,5 +117,6 @@ jobs:
           retention-days: 7
 
       - name: Update Build Number
+        if: always()
         run: |
-          curl -L -X PATCH -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.API_TOKEN }}" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/orgs/acc-hymns/actions/variables/IOS_BUILD_NUMBER -d '{"name":"IOS_BUILD_NUMBER","value":"${{ env.build_number }}"}'
+          curl -L -X PATCH -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.API_TOKEN }}" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/orgs/acc-hymns/actions/variables/IOS_BUILD_NUMBER -d '{"value":"${{ env.BUILD_NUMBER }}"}'

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -71,7 +71,6 @@ jobs:
           # Replace version codes
           xcrun agvtool new-version -all "${{ env.BUILD_NUMBER }}"
           xcrun agvtool new-marketing-version "${{ env.PACKAGE_NUMBER }}"
-          echo "MARKET_VERSION=$(xcodebuild -showBuildSettings | grep MARKETING_VERSION | tr -d 'MARKETING_VERSION = ')" >> "$GITHUB_ENV"
           xcodebuild clean archive -workspace App.xcworkspace -scheme "ACC Hymns" -destination generic/platform=iOS -archivePath App.xcarchive -allowProvisioningUpdates
           
       - name: Export IPA
@@ -111,7 +110,7 @@ jobs:
 
       - name: Publish IPA
         run: |
-          xcrun altool --upload-package "ios/App/output/ACC Hymns.ipa" --type "ios" --asc-public-id ${{ secrets.ASC_PUBLIC_ID }} --apple-id ${{ secrets.APP_APPLE_ID }} --bundle-version ${{ env.build_number }} --bundle-short-version-string "${{ env.MARKET_VERSION }}" --bundle-id "com.ChristopherW.acchmns" -u ${{ secrets.APPLE_ID }} -p ${{ secrets.APPLE_PASS }}
+          xcrun altool --upload-package "ios/App/output/ACC Hymns.ipa" --type "ios" --asc-public-id ${{ secrets.ASC_PUBLIC_ID }} --apple-id ${{ secrets.APP_APPLE_ID }} --bundle-version ${{ env.BUILD_NUMBER }} --bundle-short-version-string "${{ env.PACKAGE_NUMBER }}" --bundle-id "com.ChristopherW.acchmns" -u ${{ secrets.APPLE_ID }} -p ${{ secrets.APPLE_PASS }}
 
       - name: Upload release IPA
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -7,8 +7,19 @@ on:
       - ".github/.workflows/**"
 
 jobs:
+  wait:
+    name: Wait for Previous IOS Builds to finish
+    runs-on: ubuntu-latest
+    steps:
+      # We do this so we don't ever have conflicting build numbers
+      - name: Wait for other build-ios to conclude
+        uses: ahmadnassri/action-workflow-queue@v1
+        with:
+          timeout: 3600000
+
   build:
     name: Build IOS
+    needs: wait
     runs-on: macos-latest
 
     steps:
@@ -51,12 +62,6 @@ jobs:
           npm install
           npm run deploy-check
           npm run build
-
-      # We do this so we don't ever have conflicting build numbers
-      - name: Wait for other build-ios to conclude
-        uses: ahmadnassri/action-workflow-queue@v1
-        with:
-          timeout: 3600000
       
       - name: Get & update build number
         run: |

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -13,7 +13,6 @@ jobs:
       - uses: ahmadnassri/action-workflow-queue@v1
         with:
           timeout: 3600000
-          delay: 1000
 
   build:
     name: Build IOS
@@ -67,7 +66,7 @@ jobs:
 
       - name: Build app bundle
         run: |
-          npx cap sync
+          npx cap sync ios
           cd ios/App
           # Replace version codes
           xcrun agvtool new-version -all "${{ env.BUILD_NUMBER }}"

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -3,8 +3,6 @@ name: Build IOS
 on:
   workflow_dispatch:
   push:
-    paths-ignore:
-      - ".github/.workflows/**"
 
 jobs:
   wait:
@@ -12,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # We do this so we don't ever have conflicting build numbers
-      - name: Wait for other build-ios to conclude
-        uses: ahmadnassri/action-workflow-queue@v1
+      - uses: ahmadnassri/action-workflow-queue@v1
         with:
           timeout: 3600000
+          delay: 1000
 
   build:
     name: Build IOS
@@ -52,11 +50,6 @@ jobs:
           mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
           cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
 
-      - name: Setup XCode
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: latest-stable
-
       - name: Build web app
         run: |
           npm install
@@ -76,7 +69,9 @@ jobs:
         run: |
           npx cap sync
           cd ios/App
-          xcrun agvtool new-version -all "${{ env.BUILD_NUMBER }}" new-marketing-version "${{ env.PACKAGE_NUMBER }}"
+          # Replace version codes
+          xcrun agvtool new-version -all "${{ env.BUILD_NUMBER }}"
+          xcrun agvtool new-marketing-version "${{ env.PACKAGE_NUMBER }}"
           echo "MARKET_VERSION=$(xcodebuild -showBuildSettings | grep MARKETING_VERSION | tr -d 'MARKETING_VERSION = ')" >> "$GITHUB_ENV"
           xcodebuild clean archive -workspace App.xcworkspace -scheme "ACC Hymns" -destination generic/platform=iOS -archivePath App.xcarchive -allowProvisioningUpdates
           

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -62,6 +62,9 @@ jobs:
         run: |
           echo "PACKAGE_NUMBER=$(jq -r '.version' package.json)" >> "$GITHUB_ENV"
           echo "BUILD_NUMBER=$((${{ vars.IOS_BUILD_NUMBER }} + 1))" >> "$GITHUB_ENV"
+
+      - name: Update build number
+        run: |
           curl -L -X PATCH -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.API_TOKEN }}" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/orgs/acc-hymns/actions/variables/IOS_BUILD_NUMBER -d '{"value":"${{ env.BUILD_NUMBER }}"}'
 
       - name: Build app bundle

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acchymnal",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "scripts": {
     "postinstall": "patch-package",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acchymnal",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "private": true,
   "scripts": {
     "postinstall": "patch-package",


### PR DESCRIPTION
Add auto upload for android versions, set apple and android marketing versions (I.E. 2.0.1) based on the value of package.json.
![image](https://github.com/ACC-Hymns/acchymns-web/assets/36043275/6b2935b1-0f87-4bbf-8d56-e97860fccae9)