### PR TITLE
ES book (Evangeliumssänger) titles corrected

### DIFF
--- a/public/books/ES/songs.json
+++ b/public/books/ES/songs.json
@@ -92,7 +92,7 @@
         "notes": []
     },
     "24": {
-        "title": "Frei vom Gefeß.",
+        "title": "Frei vom Gesetz",
         "notes": []
     },
     "25": {
@@ -268,7 +268,7 @@
         "notes": []
     },
     "68": {
-        "title": "Wo sind' ich Jesum?",
+        "title": "Wo find' ich Jesum?",
         "notes": []
     },
     "69": {
@@ -1432,7 +1432,7 @@
         "notes": []
     },
     "359": {
-        "title": "Wenn des Lebens Stürme tofen.",
+        "title": "Wenn des Lebens Stürme tosen",
         "notes": []
     },
     "360": {
@@ -1692,43 +1692,43 @@
         "notes": []
     },
     "424": {
-        "title": "Willkommen!",
+        "title": "Ach wann ist mein Pilgern hier aus",
         "notes": []
     },
     "425": {
-        "title": "Des Himmels goldnes Thor.",
+        "title": "Unter einer Trauerweide",
         "notes": []
     },
     "426": {
-        "title": "Der Heimath Süßigkeit.",
+        "title": "Nach der Heimath süßer Stille",
         "notes": []
     },
     "427": {
-        "title": "Am Gnadenthor.",
+        "title": "Am Gnadenthor",
         "notes": []
     },
     "428": {
-        "title": "Jesus, der Retter.",
+        "title": "Mächtig tobt des Sturmes Brausen",
         "notes": []
     },
     "429": {
-        "title": "Das offene Fenster.",
+        "title": "Seht, wie Daniel in Babel betet",
         "notes": []
     },
     "430": {
-        "title": "Wiederkehr.",
+        "title": "Ach was habe ich getan",
         "notes": []
     },
     "431": {
-        "title": "Raum bei den Engeln.",
+        "title": "Während droben an dem Himmel",
         "notes": []
     },
     "432": {
-        "title": "Kommt.",
+        "title": "Ich weiß ein Wort, so herrlich",
         "notes": []
     },
     "433": {
-        "title": "Aufforderung zur geistlichen Mitarbeit.",
+        "title": "Geht hin in den Weinberg, das sei",
         "notes": []
     },
     "434": {
@@ -1744,31 +1744,31 @@
         "notes": []
     },
     "437": {
-        "title": "Heil dem Lamm.",
+        "title": "Preis sei Dir, mein teurer Heiland",
         "notes": []
     },
     "438": {
-        "title": "Wo ist mein Kind wohl jetzt?",
+        "title": "Wo ist wohl jetzt mein armes Kind",
         "notes": []
     },
     "439": {
-        "title": "Mein Gewinn.",
+        "title": "Sterben ist mein Gewinn.",
         "notes": []
     },
     "440": {
-        "title": "Jesus starb für mich.",
+        "title": "Sagt an, vergoß der Herr Sein Blut",
         "notes": []
     },
     "441": {
-        "title": "Neues Leben.",
+        "title": "Es lebe Gott allein in mir",
         "notes": []
     },
     "442": {
-        "title": "Der Waffenträger.",
+        "title": "Bin nur ein Waffenträger",
         "notes": []
     },
     "443": {
-        "title": "Das Rettungboot.",
+        "title": "Licht strahlt von ferne",
         "notes": []
     },
     "444": {
@@ -1776,15 +1776,15 @@
         "notes": []
     },
     "445": {
-        "title": "Erquickung.",
+        "title": "Bietet Gottes Wort den Armen",
         "notes": []
     },
     "446": {
-        "title": "Ich sing von Jesu immerdar.",
+        "title": "Möcht singen jetzt und immerdar",
         "notes": []
     },
     "447": {
-        "title": "Er kommt wieder.",
+        "title": "Unser Heiland fährt gen Himmel",
         "notes": []
     },
     "448": {
@@ -1804,7 +1804,7 @@
         "notes": []
     },
     "452": {
-        "title": "Der Friedensfürst.",
+        "title": "Horch! Die Engelchöre singen",
         "notes": []
     },
     "453": {
@@ -2056,11 +2056,11 @@
         "notes": []
     },
     "515": {
-        "title": "Die Glocke der Gnade",
+        "title": "Wenn des Heilandes Klopfen",
         "notes": []
     },
     "516": {
-        "title": "Großer Gott, großer Gott",
+        "title": "Großer Gott, wir loben dich",
         "notes": []
     },
     "517": {
@@ -2104,7 +2104,7 @@
         "notes": []
     },
     "527": {
-        "title": "Der neue Himmel",
+        "title": "Ich sah einen neuen Himmel",
         "notes": []
     },
     "528": {
@@ -2172,11 +2172,11 @@
         "notes": []
     },
     "544": {
-        "title": "Ariel.",
+        "title": "Es blutete das Lamm für mich",
         "notes": []
     },
     "545": {
-        "title": "Dir Erwartung.",
+        "title": "Ich erwarte meinen Meister",
         "notes": []
     },
     "546": {
@@ -2196,7 +2196,7 @@
         "notes": []
     },
     "550": {
-        "title": "Ich will den Herrn loben.",
+        "title": "Wie ist doch ohne Maß und Ziel",
         "notes": []
     },
     "551": {
@@ -2216,15 +2216,15 @@
         "notes": []
     },
     "555": {
-        "title": "Das selge Heut.",
+        "title": "Was mein Herz erfreut",
         "notes": []
     },
     "556": {
-        "title": "In der elften Stunde.",
+        "title": "Gehe in den Weinberg",
         "notes": []
     },
     "557": {
-        "title": "Weihnachtslied",
+        "title": "Engel künden, heute ist",
         "notes": []
     },
     "558": {
@@ -2236,7 +2236,7 @@
         "notes": []
     },
     "560": {
-        "title": "Abendlied.",
+        "title": "Vater, send uns vor dem Schlummer",
         "notes": []
     },
     "561": {
@@ -2244,7 +2244,7 @@
         "notes": []
     },
     "562": {
-        "title": "Der 23. Psalm",
+        "title": "Gott ist mein Hirt",
         "notes": []
     }
 }


### PR DESCRIPTION
- Some titles were wrong due mistakes of OCR
- All titles must be the beginning of songtext (Users generally search by the initial lyrics of the song.)